### PR TITLE
add elvex

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 | Tranglo                    | RM5000/yr 6 month bond                  | Kuala Lumpur        | 51-200          | [Link](https://tranglo.com/career/)|
 | Way2B1                     | $2500/yr                                | San Francisco       | 11-50           | [Link](https://www.way2b1.com/team#positions)|
 | Zapier                     | $2500/yr                                | San Francisco       | 501-1000        | [Link](https://zapier.com/jobs)|
-
+| Elvex                      | $2k refreshed every 4 years             | USA (100% Remote)   | 11 - 50         | [Link](https://careers.elvex.ai/jobs)|
 </div>
   
 <h3 align="center">Contribute</h3>


### PR DESCRIPTION
Add entry for elvex (the company I work for). The stipend we get is $2k every 4 years.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the companies list by adding a new entry for Elvex, which now shows details including a budget of $2k (refreshed every 4 years), a fully remote USA-based operation, a company size between 11 and 50 employees, and a direct link to their careers page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->